### PR TITLE
Fix long read alignment selection

### DIFF
--- a/bin/lr_count_table_minimap2.py
+++ b/bin/lr_count_table_minimap2.py
@@ -75,7 +75,7 @@ def hits_to_taxo(taxonomy, bam_lst):
             if not l.query_name in lr_reads[sample]:
                 lr_reads[sample][l.query_name] = read
             ## Replace taxonomy if the alignment score of another hit is better
-            elif lr_reads[sample][l.query_name]['lr_nm_score'] < read['lr_nm_score']:
+            elif lr_reads[sample][l.query_name]['lr_nm_score'] > read['lr_nm_score']:
                 lr_reads[sample][l.query_name] = read
             ## In case of same alignment score...
             elif lr_reads[sample][l.query_name]['lr_nm_score'] == read['lr_nm_score']:


### PR DESCRIPTION
This fix long read alignment selection.

Best alignment was taking the alignment with the highest NM tag but NM tag is the number of mismatch in the alignment so the alignment with the highest number of mismatch was kept as best alignment. 
 
I use the number of matches  to select the best alignment. To compute the number of matches I first computed the length of the alignment using the cigar line and subtract the number of mismatch to it. The number of matches gives an idea of the identity of the alignment as well as the coverage. 
 
Here a post of Heng li on the definition of sequence identity that helped me to correctly parse the cigar line https://lh3.github.io/2018/11/25/on-the-definition-of-sequence-identity

I discuss this modification with @alexcorm  by mail. 

